### PR TITLE
fix checksum mismatch with trailing slash

### DIFF
--- a/ims-dump.yml
+++ b/ims-dump.yml
@@ -17,7 +17,7 @@
 
     - name: fetch the backup
       fetch:
-        dest: "{{ playbook_dir }}"
+        dest: "{{ playbook_dir }}/"
         fail_on_missing: yes
         src: /tmp/db_dump/ebisc.sql.gz
         flat: yes
@@ -38,7 +38,7 @@
 
     - name: fetch the backup
       fetch:
-        dest: "{{ playbook_dir }}"
+        dest: "{{ playbook_dir }}/"
         fail_on_missing: yes
         src: /tmp/media.tar.gz
         flat: yes


### PR DESCRIPTION
With ansible 2.3 ims-dump fails with
"checksum mismatch" because
the destination is a directory,
but has no trailing slash.

This is fixed in ansible 2.4
in a way that still fails,
but changes the error message.

So we just add the trailing slash.