### PR TITLE
add HPSCREG_USER also to uwsgi service file

### DIFF
--- a/roles/ims/templates/ims-uwsgi.service.conf.j2
+++ b/roles/ims/templates/ims-uwsgi.service.conf.j2
@@ -3,6 +3,7 @@ Environment="POSTGRESQL_USER={{ postgresql_user }}"
 Environment="POSTGRESQL_PASSWORD={{ postgresql_password }}"
 Environment="POSTGRESQL_DATABASE={{ postgresql_database }}"
 Environment="DJANGO_SECRET_KEY={{ django_secret_key }}"
+Environment="HPSCREG_USER={{ hpscreg_user }}"
 Environment="SENDGRID_API_KEY={{ email_api_key }}"
 {% if ims_role == "production" %}
 Environment="BIOSAMPLES_KEY={{ biosample_key }}"

--- a/roles/ims/templates/ims-uwsgi.service.j2
+++ b/roles/ims/templates/ims-uwsgi.service.j2
@@ -20,6 +20,7 @@ ExecStart=/usr/bin/docker run --name %p \
   -e ES_HOST=ims-elasticsearch \
   -e SENDGRID_API_KEY=${SENDGRID_API_KEY} \
   -e SECRET_KEY=${DJANGO_SECRET_KEY} \
+  -e HPSCREG_USER=${HPSCREG_USER} \
   -e BIOSAMPLES_KEY=${BIOSAMPLES_KEY} \
   --publish 9191:9191 \
   --read-only \


### PR DESCRIPTION
This is needed when adding the user
as part of an external url in the settings in Python.
The url is not used in our running uwsgi instance,
but the concatenation fails if the variable is not set.
We run the hPSCreg import
in a different service file
running directly on the docker image.

This needs a
sudo systemctl restart ims-uwsgi
on the ims and ims_staging hosts in the cloud,
if not done/detected by ansible automatically.
With
docker inspect ims-uwsgi | grep =
we can check if the environment is set up
correctly on ims and ims_staging.